### PR TITLE
chore: added support for dokku v0.36

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,6 @@ jobs:
           key: "v3"
       - terraform/install:
           terraform_version: "1.1.5"
-      # Was having problems with docker <20 and dokku >= 0.26.2
-      # - docker/install-docker
       - run:
           name: Install gotestsum
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ executors:
       - image: cimg/go:<< pipeline.parameters.go-version >>
   vm:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2404:current
     environment:
       GOMODCACHE: /home/circleci/go/pkg/mod
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 
 orbs:
-  docker: circleci/docker@3.0.1
   goreleaser: hubci/goreleaser@1.0.0
   go: circleci/go@2.2.3
   terraform: circleci/terraform@2.1.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ executors:
       - image: cimg/go:<< pipeline.parameters.go-version >>
   vm:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2004:current
     environment:
       GOMODCACHE: /home/circleci/go/pkg/mod
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,8 @@ workflows:
                 - "0.32.4"
                 - "0.33.9"
                 - "0.34.9"
-                - "0.35.13"
+                - "0.35.20"
+                - "0.36.11"
           requires:
             - build
             - install-go-deps-vm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  docker: circleci/docker@2.0.1
+  docker: circleci/docker@3.0.1
   goreleaser: hubci/goreleaser@1.0.0
   go: circleci/go@2.2.3
   terraform: circleci/terraform@2.1.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ executors:
       - image: cimg/go:<< pipeline.parameters.go-version >>
   vm:
     machine:
-      image: ubuntu-2404:current
+      image: ubuntu-2204:current
     environment:
       GOMODCACHE: /home/circleci/go/pkg/mod
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
       - terraform/install:
           terraform_version: "1.1.5"
       # Was having problems with docker <20 and dokku >= 0.26.2
-      - docker/install-docker
+      # - docker/install-docker
       - run:
           name: Install gotestsum
           command: |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 This is a terraform provider for provisioning apps on [Dokku](https://dokku.com/) installations. Not all configuration options are currently supported.
 
-This provider is currently tested against Dokku >= v0.30 and <= 0.35, although can be forced to run against any version. [Read more](#Tested-dokku-versions).
+This provider is currently tested against Dokku >= v0.30 and <= 0.36, although can be forced to run against any version. [Read more](#Tested-dokku-versions).
 
 ## Key Features
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -179,7 +179,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 	log.Printf("[DEBUG] host version %v", hostVersion)
 
-	testedVersions := ">=0.30.0 <0.36.0"
+	testedVersions := ">=0.30.0 <0.37.0"
 	testedErrMsg := fmt.Sprintf("This provider has not been tested against Dokku version %s. Tested version range: %s", string(found), testedVersions)
 
 	if err == nil {


### PR DESCRIPTION
Added support for dokku v0.36

- Updated dokku versions used in acceptance test matrix to include highest published versions
- Changed dokku version check to support v0.36
- Upgraded to latest circleci/docker orb